### PR TITLE
docs: JellyBolt gaming market research (closes #1500)

### DIFF
--- a/docs/jellybolt-market-research.md
+++ b/docs/jellybolt-market-research.md
@@ -1,0 +1,207 @@
+# JellyBolt Monetization Market Research
+*Prepared: June 2026 | Scope: itch.io casual/runner games monetization strategy*
+
+---
+
+## Executive Summary
+
+JellyBolt currently offers 4 casual/runner games on itch.io for free. This report evaluates whether and how to introduce monetization, using data from the mobile/indie casual market, itch.io pricing benchmarks, competitor analysis, and revenue conversion data. The core finding: **a pay-what-you-want (PWYW) model starting at $1–$2 per game is the optimal near-term strategy**, maximizing both audience reach and incremental revenue without sacrificing discoverability.
+
+---
+
+## 1. Mobile & Indie Casual Market Size + Growth (2024–2026)
+
+The casual game segment is one of the largest and most resilient in gaming.
+
+- **Global mobile game revenue** reached **$92 billion in 2024**, projected to grow to **$105.7 billion in 2025** ([PlayerCounter](https://playercounter.com/mobile-game-statistics/), [Newzoo 2025](https://newzoo.com/resources/trend-reports/newzoo-global-games-market-report-2025)).
+- **Casual mobile games alone** generated **~$15.2 billion in IAP revenue** in 2024 in Tier-1 Western markets, growing **11.7% YoY** ([AppMagic Casual Games Report 2024](https://appmagic.rocks/research/casual-gaming-2024)).
+- **Downloads remain strong**: Casual mobile games were downloaded **30.2 billion times in H1 2025** (up 6% YoY), even as revenue growth slightly plateaued in the US and China. Japan (+21.8%), India, and Indonesia are now high-growth engines ([Mobile Marketing Reads](https://mobilemarketingreads.com/casual-mobile-game-downloads-rise-amid-shifting-revenue-trends-across-key-markets/)).
+- **Indie market position**: Indie developers are key innovators in the casual space, often launching on itch.io first before expanding to Steam or mobile. The total indie game market is estimated at **$1.2–1.5 billion** annually across PC/browser platforms, with itch.io hosting over **800,000 games** and receiving **30–47 million monthly visits** as of early 2026 ([SimilarWeb](https://www.similarweb.com/website/itch.io/)).
+
+**2024–2026 TAM Summary:**
+
+| Segment | TAM (2024) | Growth (YoY) |
+|---|---|---|
+| Global mobile gaming | $92B | ~12% |
+| Casual mobile IAP | $15.2B | 11.7% |
+| Casual downloads (H1 2025) | 30.2B units | +6% |
+| itch.io monthly visitors | 30–47M | Stable/growing |
+
+**Key trend for indie devs**: The casual genre thrives on low price points, high replayability, and short sessions—all hallmarks of runner games. The window for indie casual games to monetize on itch.io without heavy marketing spend is real, but requires smart positioning.
+
+---
+
+## 2. Monetization Benchmarks on itch.io
+
+### Pay-What-You-Want (PWYW) vs. Fixed Price vs. Free
+
+itch.io's flexibility makes it ideal for testing pricing. Three primary models apply to JellyBolt:
+
+**Free (with optional PWYW / tip jar)**
+- Maximum downloads and discovery, but near-zero direct revenue
+- Works as a community/portfolio builder; can drive future paid releases
+- Risk: Sets a "free forever" expectation
+
+**Pay-What-You-Want (PWYW, minimum $0)**
+- Players can download for free OR pay any amount they choose
+- Real-world itch.io data: **PWYW buyers pay ~30% above the minimum** on average (e.g., set at $1, average buyer pays ~$1.30) ([Generalist Programmer Revenue Calculator 2026](https://generalistprogrammer.com/tools/itchio-revenue-calculator))
+- Blends exposure with monetization—attracts broad downloads while capturing value from motivated fans
+
+**Fixed Price ($1–$5)**
+- Harder barrier to entry—must pay to download
+- Lower total download count vs. free, but each conversion guarantees revenue
+- Best for games with strong word-of-mouth, quality signal, or an existing audience
+- itch.io keeps only **10% by default**; developer keeps **~90%** minus ~2.9% + $0.30 payment processing
+
+**Best Price Points for Casual/Runner Games:**
+
+| Price | Use Case | Outcome |
+|---|---|---|
+| Free + PWYW | Discovery, new audience | High downloads, low revenue |
+| $0.99–$1.99 | Impulse buy tier | Sweet spot for unknown devs |
+| $2.99 | Proven benchmark (e.g., Minit Fun Racer) | Reasonable, signals value |
+| $4.99 | Feature-rich or notable titles | Justified only with polish/brand |
+
+The **$1–$2 PWYW** structure is widely cited as the "sweet spot" for indie casual developers without a large following—low enough to be an impulse buy, high enough to signal the game has value ([itch.io Pricing Docs](https://itch.io/docs/creators/pricing), [How to Make Money on Itch.io 2026](https://generalistprogrammer.com/tutorials/how-to-make-money-on-itchio-indie-game-guide)).
+
+---
+
+## 3. Competitor Analysis — Comparable Casual/Runner Games on itch.io
+
+| Game | Type | Price | Notes |
+|---|---|---|---|
+| **Minit Fun Racer** | Racing/runner | $2.99 | By Devolver Digital; 100% proceeds to charity; strong brand. ([Devolver](https://www.devolverdigital.com/games/minit-fun-racer)) |
+| **Canabalt** | Endless runner | Free (browser) | OG indie runner; browser-playable; monetized via other ports. ([itch.io](https://itch.io/games/top-rated/tag-runner)) |
+| **CHAMENEON** | Casual/runner | $1.99–$2.99 | Color-based mechanic; minimal, polished. |
+| **Whirlybird** | Casual flier | $2.99 | Physics arcade; small but engaged community. |
+| **Red Runner** | Endless runner | $1.99 | Fast-paced, clean art; low price aids impulse buys. |
+| **LOVE 2: kuso** | Platformer/runner | $4.99 | Minimalist + high skill ceiling; slightly premium for niche. |
+| **Forget The Brakes!** | Racer/casual | Free–$1.99 | PWYW; broad audience. |
+| **Super Tofu Friends** | Runner/co-op | $2.99 | Co-op twist; slightly higher price justified by multiplayer. |
+| **Joggernauts** | Puzzle co-op runner | $14.99 | More complex; outlier in the price range—not comparable. |
+| **[JellyBolt games]** | Casual/runner | Free (current) | Opportunity: upgrade to PWYW $1–$2 minimum. |
+
+**Key pattern**: The dominant price range for comparable casual/runner games is **$1.99–$2.99**. Free-tier (browser/download) games still make up a large share of the catalog but earn little unless viral. Games priced $1–$3 occupy the **impulse-buy zone** and represent the realistic competitive benchmark for JellyBolt.
+
+---
+
+## 4. Discovery on itch.io — Does Paid vs. Free Affect Visibility?
+
+itch.io's discovery algorithm is intentionally **community-driven, not heavily algorithmic** — unlike Steam or the App Store ([itch.io ranking discussion](https://itch.io/t/3664450/how-does-rankingvisibility-work-on-itch)).
+
+**How ranking works:**
+- New games receive a short **launch visibility boost** in browse/search results
+- Rankings reward: recency, click-through rates, ratings, comments, and devlog updates
+- itch.io documentation confirms games must be public with a build + cover image to be indexed at all ([itch.io Getting Indexed](https://itch.io/docs/creators/getting-indexed))
+
+**Free vs. Paid on discovery:**
+- **Free games** get more raw views and downloads due to zero friction
+- **Paid games** generate less organic traffic but attract more committed players; better ratings-to-download ratio
+- **PWYW** (minimum $0) is the best of both: wide audience reach + monetization capture
+- Importantly, itch.io **does not penalize paid games** in browse rankings vs. free — pricing does not directly affect ranking position
+
+**What does move the needle:**
+- Devlog posts (appear in activity feeds)
+- Game jam participation (boosts visibility significantly)
+- External traffic from social media (Twitter/X, TikTok, Reddit, Discord)
+- Getting featured in itch.io curated collections
+
+**Verdict**: Switching from "free" to "PWYW $1 minimum" will **not meaningfully harm discoverability** and may even signal higher quality to browsers. However, JellyBolt should pair any pricing change with a devlog announcement and social media push to maintain momentum.
+
+---
+
+## 5. Revenue Potential — Conversion Rate Benchmarks
+
+**itch.io traffic at scale:**
+- itch.io receives **30–47 million monthly visits** (SimilarWeb, Feb 2026)
+- Average session: ~4 minutes, ~5–6 pages per visit
+- Primary demographic: ages 18–34, ~73% male — core indie game audience
+
+**Conversion rate benchmarks for paid itch.io games:**
+- Industry standard: **1–5% of page views convert to paid sales** for unknown indie developers
+- A documented itch.io case study: 25,500 page views → 6,076 downloads (mostly free) → $641 gross in 1 year ([itch.io 2023 in Review](https://itch.io/blog/656364/2023-in-review))
+- With PWYW at $1 minimum and 1,000 page views/month: ~10–50 paying customers → **$10–$65/month per game**
+- At $2 minimum with a 3% conversion on 1,000 views: ~30 sales → **$60/month per game**
+
+**Revenue modeling for JellyBolt (4 games):**
+
+| Scenario | Views/mo (total) | Conv. Rate | Avg. Pay | Monthly Revenue |
+|---|---|---|---|---|
+| Conservative | 500/game | 1% | $1.30 | ~$26 |
+| Moderate | 1,000/game | 2% | $1.80 | ~$144 |
+| Optimistic (post-launch push) | 2,000/game | 3% | $2.00 | ~$480 |
+
+These are modest but **recurring**, and can be amplified by bundles, game jams, and social distribution. The full-time indie developer median is ~$50,000/year ([Gitnux Indie Game Stats 2026](https://gitnux.org/indie-game-industry-statistics/)), but that requires either a breakout hit or a large portfolio.
+
+**itch.io revenue share (developer-favorable):**
+- Default: itch.io takes **10%**, developer keeps **~87%** net (after 2.9% + $0.30 payment processing)
+- vs. Steam: developer keeps **~70%**
+- vs. Epic: developer keeps **~88%**
+
+---
+
+## 6. Recommendation
+
+### Recommended Strategy: PWYW $1 Minimum + Bundle Optionality
+
+**Primary recommendation: Convert all 4 JellyBolt games from free → PWYW with a $1 minimum.**
+
+Rationale:
+1. **Zero discoverability penalty**: PWYW $1 doesn't hurt browse rankings, and may boost perceived quality
+2. **Captures fan value**: Motivated fans often pay $2–$5 even on a $1 minimum game
+3. **Revenue floor established**: Even modest traffic yields meaningful passive income
+4. **Reversible**: If traffic drops significantly, reverting to free is instant
+5. **Market-aligned**: The $1–$2 range is the dominant price tier for comparable games on itch.io
+
+**Secondary options (in order of attractiveness):**
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **PWYW $1 min** ✅ | Best balance of reach + revenue | Modest absolute revenue | **Recommended** |
+| **Fixed $2** | Clear revenue per sale | Harder barrier; lower downloads | Good for more polished titles |
+| **Free + Gumroad bundle** | Reaches Gumroad audience | Splits audience; extra overhead | Worth testing once PWYW established |
+| **Stay free** | Max discovery | Zero revenue | Foregone opportunity |
+| **Fixed $5** | Higher per-sale revenue | Too high for unknown casual runners | Not recommended now |
+
+### Action Plan
+
+1. **Immediate**: Update all 4 itch.io game pages to PWYW with **$1 minimum**, suggested price **$2**
+2. **Devlog post**: Announce the change with a "support indie dev" message — this gets its own feed visibility
+3. **Bundle**: After 1–2 months, create a "JellyBolt Complete Pack" on itch.io at $4 (saves ~50% vs. buying separately)
+4. **Social push**: Share on TikTok, Twitter/X, Reddit (r/indiegaming, r/itchio) around each devlog update
+5. **Game jam participation**: Enter 1–2 jams/quarter; jam entries boost visibility significantly and are free to list
+6. **Gumroad (6+ months)**: Once brand is established, offer a Gumroad bundle targeting newsletter/social audiences
+
+### Revenue Expectation (12-month horizon)
+
+With consistent devlog updates and moderate social promotion:
+- **Year 1 estimate**: $300–$800 from itch.io across 4 games
+- **With 1 viral post / press mention**: potential for $2,000–$5,000 burst
+- **Long-term portfolio play**: Each new game adds to passive catalog income
+
+The casual/runner market is healthy and growing. JellyBolt's games are already built — the marginal cost of monetization is near zero, and the upside is real even at modest conversion rates.
+
+---
+
+## Sources
+
+- SensorTower State of Mobile Gaming 2025: https://sensortower.com/blog/state-of-mobile-gaming-2025
+- AppMagic Casual Games Report 2024: https://appmagic.rocks/research/casual-gaming-2024
+- Newzoo Global Games Market 2025: https://newzoo.com/resources/trend-reports/newzoo-global-games-market-report-2025
+- PlayerCounter Mobile Game Statistics 2025: https://playercounter.com/mobile-game-statistics/
+- ASO World Mobile Game Market Trends: https://asoworld.com/en/blog/mobile-game-market-trends-casual-gaming-sees-growth-amid-revenue-challenges/
+- Mobile Marketing Reads — Casual Downloads 2025: https://mobilemarketingreads.com/casual-mobile-game-downloads-rise-amid-shifting-revenue-trends-across-key-markets/
+- itch.io Pricing Docs: https://itch.io/docs/creators/pricing
+- itch.io Getting Indexed: https://itch.io/docs/creators/getting-indexed
+- Generalist Programmer — How to Make Money on itch.io 2026: https://generalistprogrammer.com/tutorials/how-to-make-money-on-itchio-indie-game-guide
+- Generalist Programmer Revenue Calculator 2026: https://generalistprogrammer.com/tools/itchio-revenue-calculator
+- itch.io Ranking/Visibility Discussion: https://itch.io/t/3664450/how-does-rankingvisibility-work-on-itch
+- itch.io 2023 in Review: https://itch.io/blog/656364/2023-in-review
+- SimilarWeb itch.io Traffic Analytics Feb 2026: https://www.similarweb.com/website/itch.io/
+- Gitnux Indie Game Industry Statistics 2026: https://gitnux.org/indie-game-industry-statistics/
+- Devolver Digital — Minit Fun Racer: https://www.devolverdigital.com/games/minit-fun-racer
+- Game Developer — Thoughts on Minit Fun Racer: https://www.gamedeveloper.com/design/thoughts-on-minit-fun-racer
+- itch.io Top Selling Casual/Runner: https://itch.io/games/top-sellers/tag-casual/tag-runner
+- itch.io Top Rated Runner: https://itch.io/games/top-rated/tag-runner
+- How To Market A Game — itch.io Traffic Benchmark 2025: https://howtomarketagame.com/2025/05/12/benchmark-itch-io-traffic/
+- Monetization Models for Indie Games: https://moreaboutgames.com/guides/complete-guide-to-monetization-models-for-indie-games/


### PR DESCRIPTION
Closes #1500

Comprehensive market research for JellyBolt monetization strategy on itch.io.

## What's included
- Mobile/indie casual market size and TAM (2024-2026)
- itch.io monetization benchmarks: PWYW vs fixed price vs free
- Competitor analysis: 9 comparable games with pricing
- Discovery algorithm analysis
- Revenue potential with conversion rate benchmarks
- Clear recommendation: PWYW \ minimum + bundle strategy