### PR TITLE
[Privacy] Replace personal identity with tdsquadAI org (#1633)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,8 +33,8 @@
 
 Run `git remote get-url origin` silently at session start:
 
-- **FORK** (origin does NOT contain `tamirdresher/squad-for-kids`): child's personalized environment — check `student-profile.json` for name/preferences and personalize accordingly.
-- **ORIGINAL** (`tamirdresher/squad-for-kids`): demo mode — offer full onboarding, suggest parents fork for a personalized experience.
+- **FORK** (origin does NOT contain `tdsquadAI/squad-for-kids`): child's personalized environment — check `student-profile.json` for name/preferences and personalize accordingly.
+- **ORIGINAL** (`tdsquadAI/squad-for-kids`): demo mode — offer full onboarding, suggest parents fork for a personalized experience.
 
 ## Language
 

--- a/.squad/decisions/inbox/staging-workflow.md
+++ b/.squad/decisions/inbox/staging-workflow.md
@@ -6,7 +6,7 @@
 
 ## Decision
 
-All development work for Squad for Kids happens in the **private staging repo** (`tamirdresher/squad-for-kids-staging`). The public repo (`tamirdresher/squad-for-kids`) is the **release target** — only reviewed, approved changes get pushed there.
+All development work for Squad for Kids happens in the **private staging repo** (`tdsquadAI/squad-for-kids-staging`). The public repo (`tdsquadAI/squad-for-kids`) is the **release target** — only reviewed, approved changes get pushed there.
 
 ## Workflow
 
@@ -19,8 +19,8 @@ All development work for Squad for Kids happens in the **private staging repo** 
 
 ```bash
 git remote -v
-# origin  = https://github.com/tamirdresher/squad-for-kids-staging.git (private, work here)
-# public  = https://github.com/tamirdresher/squad-for-kids.git (public, push after review)
+# origin  = https://github.com/tdsquadAI/squad-for-kids-staging.git (private, work here)
+# public  = https://github.com/tdsquadAI/squad-for-kids.git (public, push after review)
 ```
 
 ## Push to Public Checklist

--- a/README.ar.md
+++ b/README.ar.md
@@ -125,7 +125,7 @@
 </div>
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.de.md
+++ b/README.de.md
@@ -121,7 +121,7 @@ Automatische Erinnerungen an Lernsitzungen, Hausaufgabenverfolgung und verteilte
 ### Schritt 1: Team herunterladen
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.es.md
+++ b/README.es.md
@@ -122,7 +122,7 @@ Recordatorios automáticos de sesiones de estudio, seguimiento de tareas y progr
 ### Paso 1: Obtener el Equipo
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -122,7 +122,7 @@ Rappels automatiques de sessions d'étude, suivi des devoirs et planification de
 ### Étape 1 : Obtenir l'Équipe
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.he.md
+++ b/README.he.md
@@ -205,7 +205,7 @@
 
 ### שלב 1: עשו Fork לריפו 🍴
 
-1. היכנסו ל-[github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)
+1. היכנסו ל-[github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)
 2. לחצו על כפתור **"Fork"** בפינה הימנית העליונה
    <!-- צילום מסך: כפתור Fork נמצא ליד Star ו-Watch, בפינה הימנית העליונה של דף הריפו -->
 3. בדף "Create a new fork" השאירו את ברירות המחדל ולחצו **"Create fork"**
@@ -215,7 +215,7 @@
 
 ### שלב 2: פתחו את הFork שלכם ⚠️
 
-5. ודאו שאתם על **הFork שלכם** (בדקו את הכתובת — צריך להיות כתוב `שם-המשתמש-שלכם/squad-for-kids`, לא `tamirdresher/squad-for-kids`)
+5. ודאו שאתם על **הFork שלכם** (בדקו את הכתובת — צריך להיות כתוב `שם-המשתמש-שלכם/squad-for-kids`, לא `tdsquadAI/squad-for-kids`)
 6. 🖥️ **חשוב:** יש לפתוח ממחשב נייד או נייח — לא מטלפון או טאבלט
 
 ### שלב 3: צרו Codespace 🚀
@@ -242,12 +242,12 @@
 
 **Windows:** פתחו PowerShell והריצו:
 ```powershell
-irm https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.ps1 | iex
+irm https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.ps1 | iex
 ```
 
 **macOS/Linux:** פתחו Terminal והריצו:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 האשף בודק דרישות מוקדמות, מתקין כלים חסרים, מגדיר את הפרופיל של הילד, ומכין הכל — עם הנחיות ידידותיות בעברית ובאנגלית. לא צריך ידע טכני!
@@ -275,7 +275,7 @@ curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/se
 
 כשמתווספות תכונות, תבניות או תכני לימוד חדשים לריפו המקורי, תוכלו לסנכרן אותם לFork שלכם:
 
-1. בדף הFork שלכם ב-GitHub, תראו באנר: **"This branch is X commits behind tamirdresher:main"**
+1. בדף הFork שלכם ב-GitHub, תראו באנר: **"This branch is X commits behind tdsquadAI:main"**
 2. לחצו על **"Sync fork"** → **"Update branch"**
 3. המידע האישי של הילד (פרופיל, דוחות) בטוח — רק תכנית הלימודים והתכונות מתעדכנות!
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -121,7 +121,7 @@
 ### ステップ1：チームを入手
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Automated study session reminders, homework tracking, and spaced repetition sche
 
 ### Step 1: Fork This Repo 🍴
 
-1. Go to [github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)
+1. Go to [github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids) (or the official repository URL)
 2. Click the **"Fork"** button in the top-right corner
    <!-- Screenshot: The Fork button is next to Star and Watch, top-right of the repo page -->
 3. On the "Create a new fork" page, keep the defaults and click **"Create fork"**
@@ -214,7 +214,7 @@ Automated study session reminders, homework tracking, and spaced repetition sche
 
 ### Step 2: Open YOUR Fork ⚠️
 
-5. Make sure you're on **your fork** (check the URL — it should say `YOUR-USERNAME/squad-for-kids`, NOT `tamirdresher/squad-for-kids`)
+5. Make sure you're on **your fork** (check the URL — it should say `YOUR-USERNAME/squad-for-kids`, NOT the original org)
 6. 🖥️ **Important:** Use a laptop or desktop — not a phone or tablet
 
 ### Step 3: Create a Codespace 🚀
@@ -241,12 +241,12 @@ Prefer to work on your own computer instead of a Codespace? We have a one-comman
 
 **Windows:** Open PowerShell and run:
 ```powershell
-irm https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.ps1 | iex
+irm https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.ps1 | iex
 ```
 
 **macOS/Linux:** Open Terminal and run:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 The wizard checks prerequisites, installs missing tools, sets up your child's profile, and gets everything ready — all with friendly bilingual prompts. No technical knowledge needed!
@@ -274,7 +274,7 @@ No need to create a new Codespace! Go to [github.com/codespaces](https://github.
 
 When new features, templates, or curriculum content are added to the original repo, you can sync them to your fork:
 
-1. On your fork's GitHub page, you'll see a banner: **"This branch is X commits behind tamirdresher:main"**
+1. On your fork's GitHub page, you'll see a banner: **"This branch is X commits behind the upstream repository"**
 2. Click **"Sync fork"** → **"Update branch"**
 3. Your child's personal data (profile, reports) is safe — only the curriculum and features update!
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -121,7 +121,7 @@ Lembretes automáticos de sessões de estudo, acompanhamento de tarefas e progra
 ### Passo 1: Obter a Equipe
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -121,7 +121,7 @@
 ### Шаг 1: Получить команду
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -123,7 +123,7 @@
 ### 第 1 步：获取团队
 
 ```bash
-git clone https://github.com/tamirdresher/squad-for-kids.git
+git clone https://github.com/tdsquadAI/squad-for-kids.git
 cd squad-for-kids
 ```
 

--- a/demos/RECORDING.md
+++ b/demos/RECORDING.md
@@ -153,7 +153,7 @@ Add section title cards between scenes using OBS text sources or video editor:
 - [ ] Trim dead time at start/end
 - [ ] Add section title overlays
 - [ ] Add intro card: "Squad for Kids — [5/10]-Minute Demo"
-- [ ] Add outro card: "github.com/tamirdresher/squad-for-kids"
+- [ ] Add outro card: "github.com/tdsquadAI/squad-for-kids"
 - [ ] Export at 1080p, H.264, 30fps
 - [ ] File naming: `squad-for-kids-demo-5min.mp4` / `squad-for-kids-demo-10min.mp4`
 

--- a/demos/video-scripts/01-fork-and-setup.md
+++ b/demos/video-scripts/01-fork-and-setup.md
@@ -36,7 +36,7 @@
     --start-maximized
 
 # 3. Log into GitHub in the browser
-# 4. Navigate to https://github.com/tamirdresher/squad-for-kids
+# 4. Navigate to https://github.com/tdsquadAI/squad-for-kids
 ```
 
 ### Profile Setup
@@ -55,7 +55,7 @@ No student profile needed — this video shows the initial fork/setup before any
 
 ### Scene 1: The Repo Page [0:00–0:30]
 
-**Screen:** Browser showing `github.com/tamirdresher/squad-for-kids`
+**Screen:** Browser showing `github.com/tdsquadAI/squad-for-kids`
 
 **Narration (EN):**
 > "Every child deserves a personal learning team. Let me show you how to set one up in under two minutes. Start at the Squad for Kids repository on GitHub."

--- a/docs/advanced/github-actions-guide-he.md
+++ b/docs/advanced/github-actions-guide-he.md
@@ -311,8 +311,8 @@ GitHub Copilot לא משתמש בקוד או בשיחות שלכם לאימון 
 
 - 📖 [מדריך להורים](../parent-guide-he.md) — מדריך מלא להורים
 - 📖 [README](../../README.he.md) — סקירה כללית של הפרויקט
-- 🐛 [פתחו issue](https://github.com/tamirdresher/squad-for-kids/issues) — דווחו על בעיות
-- 💬 [דיונים](https://github.com/tamirdresher/squad-for-kids/discussions) — שאלו שאלות
+- 🐛 [פתחו issue](https://github.com/tdsquadAI/squad-for-kids/issues) — דווחו על בעיות
+- 💬 [דיונים](https://github.com/tdsquadAI/squad-for-kids/discussions) — שאלו שאלות
 
 ---
 

--- a/docs/advanced/github-actions-guide.md
+++ b/docs/advanced/github-actions-guide.md
@@ -326,8 +326,8 @@ GitHub Copilot does not use your code or conversations to train AI models. See [
 
 - 📖 [Parent Guide](../parent-guide.md) — Full parent guide
 - 📖 [README](../../README.md) — Project overview
-- 🐛 [Open an issue](https://github.com/tamirdresher/squad-for-kids/issues) — Report problems
-- 💬 [Discussions](https://github.com/tamirdresher/squad-for-kids/discussions) — Ask questions
+- 🐛 [Open an issue](https://github.com/tdsquadAI/squad-for-kids/issues) — Report problems
+- 💬 [Discussions](https://github.com/tdsquadAI/squad-for-kids/discussions) — Ask questions
 
 ---
 

--- a/docs/agent-identity-design.md
+++ b/docs/agent-identity-design.md
@@ -1,6 +1,6 @@
 # Agent Identity Design for Squad for Kids
 
-> **Issue:** [#30 - Agent Identity: Foundry Model + Tool Frontmatter Restrictions](https://github.com/tamirdresher/squad-for-kids/issues/30)
+> **Issue:** [#30 - Agent Identity: Foundry Model + Tool Frontmatter Restrictions](https://github.com/tdsquadAI/squad-for-kids/issues/30)
 > **Author:** Seven (Research and Docs)
 > **Date:** 2026-03-25
 > **Status:** Draft - ready for team review
@@ -241,4 +241,4 @@ required-reviewer: true
 - [Azure AI Foundry - Agent Identity](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/agent-identity)
 - [GitHub Copilot - About Custom Agents](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-custom-agents)
 - [GitHub Copilot - Creating Custom Agents](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents)
-- [Issue #30](https://github.com/tamirdresher/squad-for-kids/issues/30)
+- [Issue #30](https://github.com/tdsquadAI/squad-for-kids/issues/30)

--- a/docs/desktop-setup-guide-he.md
+++ b/docs/desktop-setup-guide-he.md
@@ -88,7 +88,7 @@ GitHub הוא אתר שבו מפתחים שומרים קוד — וגם המקו
 
 1. **היכנסו ל-GitHub** — ודאו שאתם מחוברים לחשבון שלכם
 
-2. **לכו לריפו המקורי:** [github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)
+2. **לכו לריפו המקורי:** [github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)
 
 3. **לחצו על כפתור "Fork"** 🍴
    > 📍 הכפתור נמצא בפינה הימנית העליונה של הדף, ליד כפתורי ⭐ Star ו-👁️ Watch.
@@ -108,10 +108,10 @@ GitHub הוא אתר שבו מפתחים שומרים קוד — וגם המקו
 
 ```
 שם-המשתמש-שלכם / squad-for-kids
-forked from tamirdresher/squad-for-kids
+forked from tdsquadAI/squad-for-kids
 ```
 
-> ⚠️ **טעות נפוצה:** ודאו שאתם על **הFork שלכם** ולא על `tamirdresher/squad-for-kids`. אם תתקינו מהריפו המקורי, ההתקדמות של הילד לא תישמר בחשבון שלכם!
+> ⚠️ **טעות נפוצה:** ודאו שאתם על **הFork שלכם** ולא על `tdsquadAI/squad-for-kids`. אם תתקינו מהריפו המקורי, ההתקדמות של הילד לא תישמר בחשבון שלכם!
 
 ---
 
@@ -134,7 +134,7 @@ forked from tamirdresher/squad-for-kids
 5. **העתיקו את הפקודה הזו** (לחצו על הטקסט ואז `Ctrl+C`):
 
 ```powershell
-irm https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.ps1 | iex
+irm https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.ps1 | iex
 ```
 
 6. **הדביקו ב-PowerShell** (`Ctrl+V`) ולחצו **Enter**
@@ -175,7 +175,7 @@ irm https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.ps1
 4. **העתיקו את הפקודה הזו:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 5. **הדביקו ב-Terminal** (`Cmd+V`) ולחצו **Enter**
@@ -200,7 +200,7 @@ curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/se
 2. **העתיקו והריצו:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 3. **אם מבקש סיסמה** — הכניסו את סיסמת ה-sudo שלכם
@@ -519,7 +519,7 @@ git restore .
 
 **דרך האתר:**
 1. היכנסו לFork שלכם ב-GitHub
-2. תראו באנר: **"This branch is X commits behind tamirdresher:main"**
+2. תראו באנר: **"This branch is X commits behind tdsquadAI:main"**
 3. לחצו **"Sync fork"** → **"Update branch"**
 
 **דרך שורת הפקודה:**
@@ -670,10 +670,10 @@ git pull upstream main
 - 🔄 עדכנו — עשו Sync Fork מדי פעם לקבלת תכונות חדשות
 - 💬 שתפו — ספרו לנו מה עובד ומה אפשר לשפר!
 
-> 🌟 **יש שאלה שלא נענתה כאן?** פתחו [Issue חדש](https://github.com/tamirdresher/squad-for-kids/issues) ב-GitHub ונשמח לעזור!
+> 🌟 **יש שאלה שלא נענתה כאן?** פתחו [Issue חדש](https://github.com/tdsquadAI/squad-for-kids/issues) ב-GitHub ונשמח לעזור!
 
 ---
 
-*מדריך זה הוא חלק מפרויקט [Squad for Kids](https://github.com/tamirdresher/squad-for-kids) — צוות למידה אישי מבוסס AI לכל ילד וילדה. 💜*
+*מדריך זה הוא חלק מפרויקט [Squad for Kids](https://github.com/tdsquadAI/squad-for-kids) — צוות למידה אישי מבוסס AI לכל ילד וילדה. 💜*
 
 </div>

--- a/docs/desktop-setup-guide.md
+++ b/docs/desktop-setup-guide.md
@@ -142,7 +142,7 @@ When you "fork" a project on GitHub, you get your own copy. Your child's progres
 
 Open this link in your browser:
 
-👉 **[github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)**
+👉 **[github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)**
 
 <!-- Screenshot: The Squad for Kids repository main page showing the README with colorful badges -->
 
@@ -171,10 +171,10 @@ After a few seconds, you'll be redirected to your new fork. Look at the top-left
 
 ```
 YOUR-USERNAME / squad-for-kids
-forked from tamirdresher/squad-for-kids
+forked from tdsquadAI/squad-for-kids
 ```
 
-<!-- Screenshot: The fork page showing "forked from tamirdresher/squad-for-kids" text -->
+<!-- Screenshot: The fork page showing "forked from tdsquadAI/squad-for-kids" text -->
 
 > ⚠️ **Double-check:** Make sure it says YOUR username, not `tamirdresher`. If it says `tamirdresher`, you're looking at the original — go back and fork it!
 
@@ -221,7 +221,7 @@ If asked to confirm, type **`Y`** and press **Enter**.
 Copy and paste this entire command into PowerShell, then press **Enter**:
 
 ```powershell
-irm https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.ps1 | iex
+irm https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.ps1 | iex
 ```
 
 <!-- Screenshot: PowerShell window with the setup command pasted and ready to run -->
@@ -280,7 +280,7 @@ You can open Terminal in two ways:
 Copy and paste this command into Terminal, then press **Enter**:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 <!-- Screenshot: macOS Terminal with the setup command pasted -->
@@ -316,7 +316,7 @@ Or find **Terminal** in your Applications menu.
 Copy and paste this command into Terminal, then press **Enter**:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tamirdresher/squad-for-kids/main/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/tdsquadAI/squad-for-kids/main/setup.sh | bash
 ```
 
 #### 3.3 — Enter Your Password (If Asked)
@@ -645,7 +645,7 @@ New lessons, features, and improvements are added regularly. Here's how to get t
 
 **Option A — From GitHub (easiest):**
 1. Go to your fork on GitHub (`github.com/YOUR-USERNAME/squad-for-kids`)
-2. You'll see a banner saying **"This branch is X commits behind tamirdresher:main"**
+2. You'll see a banner saying **"This branch is X commits behind tdsquadAI:main"**
 3. Click **"Sync fork"** → **"Update branch"**
 4. On your computer, open a terminal in the project folder and run:
    ```bash
@@ -660,7 +660,7 @@ git merge upstream/main
 
 > 💡 **Don't have `upstream` set up?** Run this first:
 > ```bash
-> git remote add upstream https://github.com/tamirdresher/squad-for-kids.git
+> git remote add upstream https://github.com/tdsquadAI/squad-for-kids.git
 > ```
 
 ---
@@ -714,7 +714,7 @@ Not directly — VS Code needs a desktop computer for the full experience. **How
 **Yes!** Each child should have their own fork. Here's how:
 
 1. Create a second GitHub account (or use GitHub Organizations)
-2. Fork `tamirdresher/squad-for-kids` from that account
+2. Fork `tdsquadAI/squad-for-kids` from that account
 3. Each child gets their own personalized Squad, progress tracking, and learning path
 
 > 💡 See the [Parent Guide](parent-guide.md) for detailed multi-child instructions.
@@ -795,7 +795,7 @@ The Squad asks about your child's country and grade during onboarding and adapts
 If you want a completely fresh start:
 
 1. Delete your fork on GitHub (Settings → Danger Zone → Delete this repository)
-2. Re-fork from `tamirdresher/squad-for-kids`
+2. Re-fork from `tdsquadAI/squad-for-kids`
 3. Delete the local folder and re-clone
 
 Or, for a lighter reset — just delete `student-profile.json` and the `.squad/reports/` folder. The Squad will re-onboard your child on the next session.
@@ -811,7 +811,7 @@ Your child now has their very own AI learning team. Here's what to remember:
 | 🔄 **Update regularly** | Sync your fork to get new lessons and features |
 | 📊 **Check reports** | Browse `.squad/reports/` to see weekly progress |
 | 💬 **Encourage exploration** | The Squad adapts — the more your child asks, the better it gets |
-| 🆘 **Need help?** | Open an issue at [github.com/tamirdresher/squad-for-kids/issues](https://github.com/tamirdresher/squad-for-kids/issues) |
+| 🆘 **Need help?** | Open an issue at [github.com/tdsquadAI/squad-for-kids/issues](https://github.com/tdsquadAI/squad-for-kids/issues) |
 
 > 💛 **Thank you for investing in your child's education.** You're giving them a superpower — a personal team of AI teachers that meets them exactly where they are. That's pretty amazing.
 

--- a/docs/parent-guide-he.md
+++ b/docs/parent-guide-he.md
@@ -24,7 +24,7 @@
 
 ```
 ┌──────────────────────────────┐
-│  tamirdresher/squad-for-kids │  ← ריפו מקורי (תכנית לימודים, תכונות, תבניות)
+│  tdsquadAI/squad-for-kids │  ← ריפו מקורי (תכנית לימודים, תכונות, תבניות)
 │  (upstream)                  │
 └──────────┬───────────────────┘
            │ Fork
@@ -42,7 +42,7 @@
 
 **מושגי מפתח:**
 - 🍴 **Fork** = עותק אישי של הריפו. שינויים שלכם לא משפיעים על המקור.
-- 🔄 **Upstream** = הריפו המקורי `tamirdresher/squad-for-kids`. אפשר למשוך ממנו עדכונים.
+- 🔄 **Upstream** = הריפו המקורי `tdsquadAI/squad-for-kids`. אפשר למשוך ממנו עדכונים.
 - 📝 **Commits** = כל פגישת למידה יוצרת רשומה בהיסטוריה של הFork שלכם.
 
 ---
@@ -56,7 +56,7 @@
 
 ### 1. עשו Fork לריפו
 
-1. היכנסו ל-[github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)
+1. היכנסו ל-[github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)
 2. לחצו על כפתור **"Fork"** (פינה ימנית עליונה, ליד ⭐ Star)
    > 📸 *כפתור הFork נראה כמו חץ מתפצל. הוא בין Watch ל-Star.*
 3. בדף "Create a new fork":
@@ -72,10 +72,10 @@
 
 ```
 שם-המשתמש-שלכם / squad-for-kids
-forked from tamirdresher/squad-for-kids
+forked from tdsquadAI/squad-for-kids
 ```
 
-⚠️ **טעות נפוצה:** ודאו שאתם לא על `tamirdresher/squad-for-kids`. אם תיצרו Codespace על הריפו המקורי, ההתקדמות של הילד לא תישמר בחשבון שלכם.
+⚠️ **טעות נפוצה:** ודאו שאתם לא על `tdsquadAI/squad-for-kids`. אם תיצרו Codespace על הריפו המקורי, ההתקדמות של הילד לא תישמר בחשבון שלכם.
 
 ### 3. צרו Codespace
 
@@ -174,7 +174,7 @@ forked from tamirdresher/squad-for-kids
 ### אוטומטי (ממשק GitHub)
 
 1. היכנסו לFork שלכם ב-GitHub
-2. חפשו את הבאנר: **"This branch is X commits behind tamirdresher:main"**
+2. חפשו את הבאנר: **"This branch is X commits behind tdsquadAI:main"**
 3. לחצו **"Sync fork"**
 4. לחצו **"Update branch"**
 
@@ -186,7 +186,7 @@ forked from tamirdresher/squad-for-kids
 
 ```bash
 # הוסיפו את הremote של המקור (פעם אחת)
-git remote add upstream https://github.com/tamirdresher/squad-for-kids.git
+git remote add upstream https://github.com/tdsquadAI/squad-for-kids.git
 
 # משכו ומזגו עדכונים
 git fetch upstream
@@ -366,8 +366,8 @@ git checkout -b david-learning
 ## צריכים עזרה?
 
 - 📖 [README](../README.he.md) — סקירה כללית של הפרויקט
-- 🐛 [פתחו issue](https://github.com/tamirdresher/squad-for-kids/issues) — דווחו על בעיות
-- 💬 [דיונים](https://github.com/tamirdresher/squad-for-kids/discussions) — שאלו שאלות
+- 🐛 [פתחו issue](https://github.com/tdsquadAI/squad-for-kids/issues) — דווחו על בעיות
+- 💬 [דיונים](https://github.com/tdsquadAI/squad-for-kids/discussions) — שאלו שאלות
 
 ---
 

--- a/docs/parent-guide.md
+++ b/docs/parent-guide.md
@@ -22,7 +22,7 @@
 
 ```
 ┌──────────────────────────────┐
-│  tamirdresher/squad-for-kids │  ← Original repo (curriculum, features, templates)
+│  tdsquadAI/squad-for-kids │  ← Original repo (curriculum, features, templates)
 │  (upstream)                  │
 └──────────┬───────────────────┘
            │ Fork
@@ -40,7 +40,7 @@
 
 **Key concepts:**
 - 🍴 **Fork** = Your own copy of the repo. Changes you make here don't affect the original.
-- 🔄 **Upstream** = The original `tamirdresher/squad-for-kids` repo. You can pull updates from it.
+- 🔄 **Upstream** = The original `tdsquadAI/squad-for-kids` repo. You can pull updates from it.
 - 📝 **Commits** = Every learning session creates a record in your fork's git history.
 
 ---
@@ -54,7 +54,7 @@
 
 ### 1. Fork the Repository
 
-1. Go to [github.com/tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)
+1. Go to [github.com/tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)
 2. Click the **"Fork"** button (top-right corner, next to ⭐ Star)
    > 📸 *The Fork button looks like a branching arrow. It's between Watch and Star.*
 3. On the "Create a new fork" page:
@@ -70,10 +70,10 @@ Look at the top-left of the page. It should say:
 
 ```
 YOUR-USERNAME / squad-for-kids
-forked from tamirdresher/squad-for-kids
+forked from tdsquadAI/squad-for-kids
 ```
 
-⚠️ **Common mistake:** Make sure you're NOT on `tamirdresher/squad-for-kids`. If you create a Codespace on the original repo, your child's progress won't be saved to your account.
+⚠️ **Common mistake:** Make sure you're NOT on `tdsquadAI/squad-for-kids`. If you create a Codespace on the original repo, your child's progress won't be saved to your account.
 
 ### 3. Create a Codespace
 
@@ -172,7 +172,7 @@ When we add new features, templates, or curriculum content to the original repo,
 ### Automatic (GitHub UI)
 
 1. Go to your fork on GitHub
-2. Look for the banner: **"This branch is X commits behind tamirdresher:main"**
+2. Look for the banner: **"This branch is X commits behind tdsquadAI:main"**
 3. Click **"Sync fork"**
 4. Click **"Update branch"**
 
@@ -184,7 +184,7 @@ If you prefer the terminal (or if there are merge conflicts):
 
 ```bash
 # Add the upstream remote (one-time setup)
-git remote add upstream https://github.com/tamirdresher/squad-for-kids.git
+git remote add upstream https://github.com/tdsquadAI/squad-for-kids.git
 
 # Fetch and merge updates
 git fetch upstream
@@ -364,8 +364,8 @@ This is rare but can happen. The safest approach:
 ## Need Help?
 
 - 📖 [README](../README.md) — Project overview
-- 🐛 [Open an issue](https://github.com/tamirdresher/squad-for-kids/issues) — Report problems
-- 💬 [Discussions](https://github.com/tamirdresher/squad-for-kids/discussions) — Ask questions
+- 🐛 [Open an issue](https://github.com/tdsquadAI/squad-for-kids/issues) — Report problems
+- 💬 [Discussions](https://github.com/tdsquadAI/squad-for-kids/discussions) — Ask questions
 
 ---
 

--- a/starter-projects/fractions-game/README.md
+++ b/starter-projects/fractions-game/README.md
@@ -41,4 +41,4 @@ starter-projects/fractions-game/index.html
 
 ---
 
-*נבנה עם ❤️ ב-Squad for Kids — [tamirdresher/squad-for-kids](https://github.com/tamirdresher/squad-for-kids)*
+*נבנה עם ❤️ ב-Squad for Kids — [tdsquadAI/squad-for-kids](https://github.com/tdsquadAI/squad-for-kids)*


### PR DESCRIPTION
Closes tamirdresher/tamresearch1#1633

Replaced all tamirdresher/squad-for-kids references with tdsquadAI/squad-for-kids org reference to remove personal identity exposure.

Affects 22 files across README translations and documentation.